### PR TITLE
fixed treatment of an existing source version of gtsam

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,10 @@ endif()
 
 
 # Check if the source version of GTSAM is available
-find_package(gtsam)
-if(gtsam_FOUND)
-  message("+++ Found source version of GTSAM")
+find_package(GTSAM)
+if(GTSAM_FOUND)
+  message("+++ Found source version of GTSAM (using ${GTSAM_INCLUDE_DIR})")
+  add_dependencies(${PROJECT_NAME}_package GTSAM)
 else()
   message("--- No source version of GTSAM found. Downloading.")
   include(ExternalProject)


### PR DESCRIPTION
(the cmake scripts gtsam creates in devel space at least are all capital!)

I'm not sure if that would break on other installations. Could somebody check?
