### PR TITLE
CMake 2.8.3 does not support CONFIG, use NO_MODULE instead

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 
 
 # Check if the source version of GTSAM is available
-find_package(gtsam CONFIG CONFIGS gtsamConfig.cmake GTSAMConfig.cmake)
+find_package(gtsam NO_MODULE CONFIGS gtsamConfig.cmake GTSAMConfig.cmake)
 if(gtsam_FOUND)
   message("+++ Found source version of GTSAM (using ${GTSAM_INCLUDE_DIR})")
   add_dependencies(${PROJECT_NAME}_package gtsam)


### PR DESCRIPTION
As discussed in https://github.com/ethz-asl/gtsam_catkin/issues/13

```
cmake_minimum_required(VERSION 2.8.3)
```

2.8.3 does not support CONFIG; use the backward compatible NO_MODULE instead

"The CONFIG option may be used to skip Module mode explicitly and switch to Config mode. It is synonymous to using NO_MODULE. " (http://www.cmake.org/cmake/help/v3.0/command/find_package.html)
