### PR TITLE
Use eigen_catkin's exported include directories as hint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(gtsam_catkin)
 
 find_package(catkin_simple REQUIRED)
 
+find_package(eigen_catkin REQUIRED)
+
 catkin_simple()
 
 include(ExternalProject)
@@ -11,7 +13,7 @@ ExternalProject_Add(gtsam_src
   GIT_REPOSITORY https://bitbucket.org/gtborg/gtsam.git
   GIT_TAG 687ae3d2511b9c296af08ec2f2e717b0627a8d68
   UPDATE_COMMAND ""
-  CONFIGURE_COMMAND cmake -DCMAKE_INSTALL_PREFIX:PATH=${CATKIN_DEVEL_PREFIX} -DGTSAM_USE_SYSTEM_EIGEN=ON
+  CONFIGURE_COMMAND cmake -DCMAKE_INSTALL_PREFIX:PATH=${CATKIN_DEVEL_PREFIX} -DGTSAM_USE_SYSTEM_EIGEN=ON -DEIGEN3_INCLUDE_DIR=${eigen_catkin_INCLUDE_DIRS}
   -DCMAKE_BUILD_TYPE=Release ../gtsam_src
   BUILD_COMMAND make
   INSTALL_COMMAND make install


### PR DESCRIPTION
If `eigen_catkin` was built from an external source, `gtsam_cakin` can't seem to find Eigen's include directories.