### PR TITLE
Allow building gtsam with ccache or other compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ ExternalProject_Add(gtsam_src
   PATCH_COMMAND patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/use_catkinized_metis.patch &&
   patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/fix_warnings.patch
   CONFIGURE_COMMAND cmake -DCMAKE_INSTALL_PREFIX:PATH=${CATKIN_DEVEL_PREFIX} -DGTSAM_USE_SYSTEM_EIGEN=ON
-  -DCMAKE_BUILD_TYPE=Release ../gtsam_src
+  -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} ../gtsam_src
   BUILD_COMMAND make -j2
   INSTALL_COMMAND make install
 )


### PR DESCRIPTION
If you build your workspace with a non-default compiler, gtsam still gets built with the system default compiler. This change allows passing the chosen compiler to the external project.

In my case, I want to use ccache, which speeds up subsequent clean builds of gtsam_catkin to seconds.

Maybe also `CMAKE_CXX_FLAGS` could be passed to gtsam, but I'm not sure if that would be 100% safe.